### PR TITLE
Trickle down charset into message encoding.

### DIFF
--- a/src/SxMail/SxMail.php
+++ b/src/SxMail/SxMail.php
@@ -239,6 +239,10 @@ class SxMail
 
         $body    = $this->manipulateBody($body, $mimeType);
         $message = new Message;
+        
+        if (!empty($this->config['charset'])) {
+            $message->setEncoding($this->config['charset']);
+        }
 
         $message->setBody($body);
 


### PR DESCRIPTION
If we're setting mime charset in `manipulateBody()`, then we should also set `Mail\Message::setEncoding()` to match the `charset` in configuration, otherwise we'll have malformed subject lines.
